### PR TITLE
Replacing quotation marks with doubled apostrophes in Vault commit message

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,5 @@ Chalk is a command-line utility for export of commits from SourceGear Vault repo
 
 Chalk is not optimized for speed (yet) as it's primary use case is to export commits nightly to a Phabricator-managed Git repository. This way it is possible to perform code reviews even when there is no code review tool supporting aging SourceGear Vault.
 
-## Known issues
-- A commit with message containing double-quotes (") in Vault, will crash chalk - this is a bug in the Vault command line client that generates invalid XML (i.e. it does not escape quotes) when such message is present.
-
 ## Licence
 Apache 2, see LICENCE.txt.


### PR DESCRIPTION
Known issue solved - Replacing quotation marks with doubled apostrophes in Vault commit message.
